### PR TITLE
Improve hooks

### DIFF
--- a/src/schema.js
+++ b/src/schema.js
@@ -337,16 +337,16 @@ TransactionSchema.methods.commit = async function commit(callback) {
         await this._doHooks('post', 'commit');
     } catch (e) {
         await this._doHooks('finalize');
+        if (callback) {
+            return callback(e);
+        }
         throw e;
     }
     await this._doHooks('finalize');
 
-    const promise = Promise.resolve();
-
     if (callback) {
-        return promise.then(callback).catch(callback);
+        callback();
     }
-    return promise;
 };
 
 // ### Transaction.pre
@@ -674,16 +674,16 @@ TransactionSchema.methods.expire = async function expire(callback) {
         await this._doHooks('post', 'expire');
     } catch (e) {
         await this._doHooks('finalize');
+        if (callback) {
+            return callback(e);
+        }
         throw e;
     }
     await this._doHooks('finalize');
 
-    const promise = Promise.resolve();
-
     if (callback) {
-        return promise.then(callback).catch(callback);
+        callback();
     }
-    return promise;
 };
 
 // ### Transaction.cancel

--- a/test/transaction.test.js
+++ b/test/transaction.test.js
@@ -832,13 +832,13 @@ describe('Transaction state conflict', () => {
     );
 });
 
-describe('after-commit hook', () => {
+describe('post commit hook', () => {
     it('execute after commit', ma(async() => {
         const x = await createSavedTestDoc();
         const t = await Transaction.begin();
         await t.add(x);
         let hookValue = 0;
-        t.afterCommit(() => {
+        t.post('commit', () => {
             hookValue = 1;
         });
         should.equal(hookValue, 0);
@@ -850,7 +850,7 @@ describe('after-commit hook', () => {
         const t = await Transaction.begin();
         await t.add(x);
         let hookValue = 0;
-        t.afterCommit(() => {
+        t.post('commit', () => {
             hookValue = 1;
         });
         await t.cancel();
@@ -860,11 +860,11 @@ describe('after-commit hook', () => {
         const x = await createSavedTestDoc();
         const t = await Transaction.begin();
         await t.add(x);
-        t.afterCommit(() => {
+        t.post('commit', () => {
             throw new Exception('IGNORE ME');
         });
         let hookValue = 0;
-        t.afterCommit(() => {
+        t.post('commit', () => {
             hookValue = 1;
         });
         should.equal(hookValue, 0);
@@ -876,7 +876,7 @@ describe('after-commit hook', () => {
         const t = await Transaction.begin();
         await t.add(x);
         let hookValue = 0;
-        t.afterCommit(async() => {
+        t.post('commit', async() => {
             await new Promise((resolve) => {
                 setTimeout(() => {
                     hookValue = 1;
@@ -892,7 +892,7 @@ describe('after-commit hook', () => {
         const x = await createSavedTestDoc();
         const t = await Transaction.begin();
         await t.add(x);
-        t.afterCommit(async() => {
+        t.post('commit', async() => {
             await new Promise((resolve) => {
                 setTimeout(() => {
                     resolve();
@@ -902,7 +902,7 @@ describe('after-commit hook', () => {
             });
         });
         let hookValue = 0;
-        t.afterCommit(async() => {
+        t.post('commit', async() => {
             await new Promise((resolve) => {
                 setTimeout(() => {
                     hookValue = 1;
@@ -921,10 +921,10 @@ describe('after-commit hook', () => {
 
         let hookValue = 0;
         let hookValue2 = 0;
-        t.afterCommit(() => {
+        t.post('commit', () => {
             hookValue = 1;
         });
-        t.afterCommit(() => {
+        t.post('commit', () => {
             hookValue2 = 2;
         });
         should.equal(hookValue, 0);
@@ -937,7 +937,7 @@ describe('after-commit hook', () => {
         const x = await createSavedTestDoc();
         const t = await Transaction.begin();
         await t.add(x);
-        t.afterCommit(() => {
+        t.post('commit', () => {
             throw new Exception('IGNORE ME');
         });
         let hookValue = 0;
@@ -951,7 +951,7 @@ describe('after-commit hook', () => {
         const t = await Transaction.begin();
         await t.add(x);
         let hookValue = 0;
-        t.afterCommit(() => {
+        t.post('commit', () => {
             hookValue = 1;
         });
         try {


### PR DESCRIPTION
- reformat `afterCommit(hook)` to `post('commit', hook)
- add more hook types; `pre/post commit`, `pre/post expire` and `finalize`

resolve #3
resolve #6