### PR TITLE
Model base pre post hook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,25 @@ node_js:
     - 8
 
 env:
-    - MONGOOSE_VERSION=4.6.x
-    - MONGOOSE_VERSION=4.7.x
+    - MONGOOSE_VERSION=4.6.x MONGODB=3.4.19
+    - MONGOOSE_VERSION=4.7.x MONGODB=3.4.19
 
-services:
-    - mongodb
+matrix:
+    fast_finish: true
+
+install:
+    - curl -L http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-${MONGODB}.tgz | tar xz
+    - ${PWD}/mongodb-linux-x86_64-${MONGODB}/bin/mongod --version
+
+before_script:
+    - mkdir ${PWD}/mongodb-linux-x86_64-${MONGODB}/data
+    - ${PWD}/mongodb-linux-x86_64-${MONGODB}/bin/mongod --dbpath ${PWD}/mongodb-linux-x86_64-${MONGODB}/data --logpath ${PWD}/mongodb-linux-x86_64-${MONGODB}/mongodb.log --fork
 
 script:
     - cp test/config.js.sample test/config.js
     - npm install -d
     - npm install mongoose@${MONGOOSE_VERSION}
     - npm test
+
+after_script:
+    - pkill mongod

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "version": "0.0.1",
   "author": "Sunguk Lee <sulee@ea.com>",
   "keywords": [
-      "mongodb",
-      "mongoose",
-      "transaction"
+    "mongodb",
+    "mongoose",
+    "transaction"
   ],
   "license": "MIT",
   "dependencies": {
@@ -19,13 +19,13 @@
   },
   "devDependencies": {
     "should": "",
-    "mocha": "",
+    "mocha": "^5.1.0",
     "mongoose": "4.7.7"
   },
   "main": "lib/index.js",
   "scripts": {
-      "postinstall": "npm run build",
-      "build": "babel src --out-dir lib",
-      "test": "mocha --compilers js:babel-core/register -t 10000"
+    "postinstall": "npm run build",
+    "build": "babel src --out-dir lib",
+    "test": "mocha --compilers js:babel-core/register -t 10000"
   }
 }

--- a/src/hook.js
+++ b/src/hook.js
@@ -25,7 +25,7 @@ class Hook {
         // TODO: unique
     }
 
-    async doHooks(...types) {
+    async doHooks(context, ...types) {
         const group = types.join('_');
         if (!this.hooks || !this.hooks[group] || !this.hooks[group].length) {
             return;
@@ -41,7 +41,7 @@ class Hook {
 
         const promises = this.hooks[group].map(async(f) => {
             try {
-                await f();
+                await f(context);
             } catch(e) {
                 const msg = e.stack || e.message || e.toString();
                 process.stderr.write(msg + '\n');
@@ -60,6 +60,14 @@ class Hook {
 
     finalize(hook) {
         this._addHook('finalize', hook);
+    }
+
+    clone(once = true) {
+        const hook = new Hook(once);
+        Object.keys(this.hooks).forEach((key) => {
+            hook.hooks[key] = this.hooks[key].slice();
+        });
+        return hook;
     }
 };
 

--- a/src/hook.js
+++ b/src/hook.js
@@ -1,0 +1,66 @@
+'use strict';
+require('songbird');
+
+const PRE_POST_HOOK_TYPES = ['commit', 'expire'];
+
+class Hook {
+    constructor(once = false) {
+        this.once = once;
+        this.hooks = {
+            finalize: [],
+        };
+        PRE_POST_HOOK_TYPES.forEach((type) => {
+            this.hooks['pre_' + type] = [];
+            this.hooks['post_' + type] = [];
+        });
+    }
+
+    _addHook(types, hook) {
+        const group = (Array.isArray(types) ? types : [types]).join('_');
+        // not supported this.
+        if (!Array.isArray(this.hooks[group])) {
+            return;
+        }
+        this.hooks[group].push(hook);
+        // TODO: unique
+    }
+
+    async doHooks(...types) {
+        const group = types.join('_');
+        if (!this.hooks || !this.hooks[group] || !this.hooks[group].length) {
+            return;
+        }
+
+        if (this.once) {
+            if (this.hooks[group].called) {
+                return;
+            }
+            // prevent double call
+            this.hooks[group].called = true;
+        }
+
+        const promises = this.hooks[group].map(async(f) => {
+            try {
+                await f();
+            } catch(e) {
+                const msg = e.stack || e.message || e.toString();
+                process.stderr.write(msg + '\n');
+            }
+        });
+        await Promise.all(promises);
+    }
+
+    pre(type, hook) {
+        this._addHook(['pre', type], hook);
+    }
+
+    post(type, hook) {
+        this._addHook(['post', type], hook);
+    }
+
+    finalize(hook) {
+        this._addHook('finalize', hook);
+    }
+};
+
+module.exports = Hook;

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ const TransactionError = require('./error');
 const DEFINE = require('./define');
 const TransactionSchema = require('./schema');
 const ModelMap = require('./modelmap');
+const Hook = require('./hook');
 const ERROR_TYPE = DEFINE.ERROR_TYPE;
 
 module.exports = {
@@ -416,6 +417,13 @@ const findWaitUnlock = (proto) => {
 module.exports.TransactedModel = (connection, modelName, schema) => {
     schema.plugin(module.exports.plugin);
     const model = connection.model(modelName, schema);
+    const hooks = model._hooks = new Hook();
+
+    model.pre = (...args) => hooks.pre(...args);
+    model.post = (...args) => hooks.post(...args);
+    model.finalize = (...args) => hooks.finalize(...args);
+    model._doHooks = (...args) => hooks.clone().doHooks(...args);
+
     ModelMap.addCollectionPseudoModelPair(model.collection.name, connection,
                                           schema);
 


### PR DESCRIPTION
now we can add the hook on the `model`

```
const Model  = Transaction.TransactedModel(...);
Model.pre('commit', (doc) => {
  // do extra checking or emitting.
});
```
but it doesn't work chaining like the original hook of the `mongoose`.